### PR TITLE
Fix typo in Von Fiend's name to Von Feind

### DIFF
--- a/docs/bosses/von-feind.md
+++ b/docs/bosses/von-feind.md
@@ -1,0 +1,3 @@
+# Von Feind
+
+He is a supernaturally buff Vindicator that has a huge number of hit points and hits hard enough to kill a player in two hits. Von Feind is also skilled, as he only kills his enemies by chopping their head clean off. When a player is murdered by Von Feind for the first time they will achieve the [Off with your head!](../advancements.md#off-with-your-head) advancement. When Von chop's the players head off he will hold their head in his hand. Picking up a second head, Von will replace the one they are currently carrying. The head Von holds upon death will drop as loot.

--- a/docs/bosses/von-fiend.md
+++ b/docs/bosses/von-fiend.md
@@ -1,3 +1,0 @@
-# Von Fiend
-
-He is a supernaturally buff Vindicator that has a huge number of hit points and hits hard enough to kill a player in two hits. Von Fiend is also skilled, as he only kills his enemies by chopping their head clean off. When a player is murdered by Von Fiend for the first time they will achieve the [Off with your head!](../advancements.md#off-with-your-head) advancement. When Von chop's the players head off he will hold their head in his hand. Picking up a second head, Von will replace the one they are currently carrying. The head Von holds upon death will drop as loot.


### PR DESCRIPTION
His name is Von Feind. Feind is German and means enemy. Von is a suffix to a last name that was formerly used to indicate origin or noble status.

Feind: Derived from the Old High German word *fiant* or *vint* (originally meaning “hatred” or “the hater”)